### PR TITLE
Added region information to S3 bucket creation step

### DIFF
--- a/setup_infra.sh
+++ b/setup_infra.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ $# -eq 0 ]] ; then
-    echo 'Please enter your bucket name as ./setup_infra.sh your-bucket'
+if [[ $# != 2 ]] ; then
+    echo 'Please enter your bucket name & region name as ./setup_infra.sh your-bucket your-region'
     exit 0
 fi
 
@@ -22,8 +22,8 @@ REDSHIFT_PASSWORD=sdeP0ssword0987
 REDSHIFT_PORT=5439
 EMR_NODE_TYPE=m4.xlarge
 
-echo "Creating bucket "$1""
-aws s3api create-bucket --acl public-read-write --bucket $1 --output text >> setup.log
+echo "Creating bucket "$1" in region "$2""
+aws s3api create-bucket --acl public-read-write --bucket $1 --region $AWS_REGION --create-bucket-configuration LocationConstraint=$2 --output text >> setup.log
 
 echo "Clean up stale local data"
 rm -f data.zip


### PR DESCRIPTION
Hi Joseph,
 
I tried running the `setup_infra.sh` on my machine & found that `region` information is required to create the bucket. This is a mandate except the region US Ease (N. Virginia)

Additionally, I thought it would be better if this information can be asked at the time of script invokation. Hence I asked for `region` information as an additional parameter along with exising `bucket_name`.

Thanks,
Stallians

References:
1. [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html)
2. [Stack Overflow issue](https://stackoverflow.com/questions/49174673/aws-s3api-create-bucket-bucket-make-exception)